### PR TITLE
Standalone Kafka docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 book/_build/*
 book/.ipynb_checkpoints/*
+.vscode

--- a/kafka/docker-compose-tend.yaml
+++ b/kafka/docker-compose-tend.yaml
@@ -1,0 +1,65 @@
+version: '3.7'
+services: 
+    zookeeper:
+        image: confluentinc/cp-zookeeper:6.1.1
+        container_name: zookeeper
+        ports:
+            - "2181:2181"
+        environment:
+            ZOOKEEPER_CLIENT_PORT: 2181
+            ZOOKEEPER_SERVER_ID: "1"
+        networks: 
+                - tap
+
+    kafkaserver:
+        image: confluentinc/cp-kafka:6.1.1
+        container_name: kafkaserver
+        hostname: kafkaServer
+        depends_on:
+          - zookeeper
+        ports:
+          - "9092:9092"
+          - "9101:9101"
+        environment:
+          KAFKA_BROKER_ID: 0
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafkaserver:9092
+          KAFKA_DEFAULT_REPLICATION_FACTOR: 2
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 2
+        networks: 
+            - tap
+
+    kafkaworker1:
+        image: confluentinc/cp-kafka:6.1.1
+        container_name: kafkaWorker1
+        depends_on:
+          - zookeeper
+        environment:
+          KAFKA_BROKER_ID: 1
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafkaworker1:9092
+          KAFKA_DEFAULT_REPLICATION_FACTOR: 2
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 2
+        networks: 
+            - tap
+
+    webui:
+        image: provectuslabs/kafka-ui:latest
+        container_name: kafkaWebUI
+        environment:
+            KAFKA_CLUSTERS_0_NAME: my_cluster
+            KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafkaServer:9092
+        ports: 
+            - 8080:8080
+        depends_on: 
+            - kafkaserver
+        networks: 
+            - tap
+
+networks:
+    tap:
+        name: tap
+        driver: bridge

--- a/python/bin/tap10linesConsumer.py
+++ b/python/bin/tap10linesConsumer.py
@@ -1,13 +1,16 @@
 # https://towardsdatascience.com/kafka-python-explained-in-10-lines-of-code-800e3e07dad
+import os
 from kafka import KafkaConsumer
 from json import loads
 
+topic = os.getenv("KAFKA_TOPIC", "tap")
+group_id = os.getenv("GROUP_ID", "my-group")
 consumer = KafkaConsumer(
-    'tap',
+     topic,
      bootstrap_servers=['kafkaServer:9092'],
      auto_offset_reset='latest',
      enable_auto_commit=True,
-     group_id='my-group',
+     group_id=group_id,
      value_deserializer=lambda x: loads(x.decode('utf-8')))
 
 for message in consumer:

--- a/python/bin/tap10linesProducer.py
+++ b/python/bin/tap10linesProducer.py
@@ -1,13 +1,15 @@
 # https://towardsdatascience.com/kafka-python-explained-in-10-lines-of-code-800e3e07dad
+import os
 from time import sleep
 from json import dumps
 from kafka import KafkaProducer
 
+topic = os.getenv("KAFKA_TOPIC", "tap")
 producer = KafkaProducer(bootstrap_servers=['kafkaServer:9092'],
-                         value_serializer=lambda x: 
+                         value_serializer=lambda x:
                          dumps(x).encode('utf-8'))
 
 for e in range(1000):
     data = {'number' : e}
-    producer.send('tap', value=data)
+    producer.send(topic, value=data)
     sleep(5)


### PR DESCRIPTION
Aggiunto il file _kafka/docker-compose-tend.yaml_, che comprende:
- **zookeeper** da _confluentinc/cp-zookeeper:6.1.1_
    - fa il suo lavoro da zookeeper
- **kafkaserver** e **kafkaworker1** da _confluentinc/cp-kafka:6.1.1_
    - rappresentano due broker kafka. Il primo è inteso come entrypoint, puramente a scopo organizzativo
    - per mostrare gli effetti della replication, che è settata ad un fattore 2. Lo si deve abbassare se si vuole eliminare il worker
    - se ne possono facilmente aggiungere quanti se ne vuole, purché la variabile KAFKA_BROKER_ID sia univoca.
- **webui** da _provectuslabs/kafka-ui:latest_
     - offre una UI per visualizzare meglio lo stato del cluster
    
**Non** ha bisogno di alcun file esterno. Tutta la configurazione è effettuata con le variabili d'ambiente.
**Non** comprende producer e consumer, che si possono aggiungere come container standalone, ad esempio i _tap10lines_, purché utilizzino la **network tap**.
Tutte le immagini utilizzate sono **Community licensed**. Maggiori info [qui](https://docs.confluent.io/platform/current/installation/docker/image-reference.html)

---

Inoltre, come modifiche minori:
- aggiunta la cartella .vscode al .gitignore (per tutti gli appassionati di VsCode)
- aggiunta la possibilità di modificare il **gruppo** del consumatore e il **topic** tramite le variabili d'ambiente  **GROUP_ID** e **KAFKA_TOPIC** nei file python _tap10linesConsumer.py_ e _tap10linesProducer.py_