### PR TITLE
Twitter pipeline con logstash-kafka-spark-elastic

### DIFF
--- a/kibana/docker-compose-tend.yaml
+++ b/kibana/docker-compose-tend.yaml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services: 
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
+        container_name: elasticsearch
+        ports:
+            - "9200:9200"
+        environment:
+            - node.name=elasticsearch
+            - cluster.name=elasticsearch-docker-cluster
+            - discovery.seed_hosts=elasticsearch
+            - cluster.initial_master_nodes=elasticsearch
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        networks: 
+            - tap
+
+    kibana:
+        image: docker.elastic.co/kibana/kibana:7.12.1
+        container_name: kibana
+        ports:
+            - "5601:5601"
+        networks: 
+            - tap
+
+networks:
+    tap:
+        name: tap
+        driver: bridge

--- a/logstash_to_kafka/Dockerfile
+++ b/logstash_to_kafka/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/logstash/logstash:7.11.2
+
+COPY pipeline/*.conf /usr/share/logstash/pipeline/

--- a/logstash_to_kafka/pipeline/logstash.conf
+++ b/logstash_to_kafka/pipeline/logstash.conf
@@ -1,0 +1,21 @@
+input {
+  twitter {
+      consumer_key => "aBSmvhViNyM3HdDRVv4j3VXlc"
+      consumer_secret => "iW7flg2FzvAQqZc9YAzUe7NovcLFMqhFWt7XyySJuF6t40ZX3y"
+      oauth_token => "113286276-ayCtRJVxgBB1dRqPF8TE8wWLuLdjfwYGNp9hQGDS"
+      oauth_token_secret => "pjxCfX0dI5AAV1sQfcbktBy9mn6yH8hFodQm2iWRAzz5i"
+      keywords => ["#Mourinho"]
+      full_tweet => true
+  }
+}
+
+filter {
+}
+
+output {
+  kafka {
+    codec => json
+    topic_id => "tweet"
+    bootstrap_servers => "kafkaserver:9092"
+  }
+}

--- a/spark/code/twitter_stream_elastic.py
+++ b/spark/code/twitter_stream_elastic.py
@@ -1,0 +1,125 @@
+from pyspark import SparkContext
+from pyspark.sql.session import SparkSession
+from pyspark.conf import SparkConf
+from pyspark import SparkContext
+from pyspark.sql.session import SparkSession
+from pyspark.sql.functions import from_json
+import pyspark.sql.types as tp
+from pyspark.ml import Pipeline
+from pyspark.ml.feature import StopWordsRemover, Word2Vec, RegexTokenizer
+from pyspark.ml.classification import LogisticRegression
+from pyspark import SparkContext
+from pyspark.sql import SparkSession
+from elasticsearch import Elasticsearch
+
+elastic_host="elasticsearch"
+elastic_index="taptweet"
+kafkaServer="kafkaServer:9092"
+topic = "tweet"
+
+
+
+## is there a field in the mapping that should be used to specify the ES document ID
+# "es.mapping.id": "id"
+# Credit for mapping https://medium.com/@CMpoi/elasticsearch-defining-the-mapping-of-twitter-data-dafad0f50695 Timestamp
+
+es_mapping = {
+    "mappings": {
+        "properties": 
+            {
+                "created_at": {"type": "date","format": "EEE MMM dd HH:mm:ss Z yyyy"},
+                "text": {"type": "text","fielddata": True}
+            }
+    }
+}
+
+es = Elasticsearch(hosts=elastic_host) 
+# make an API call to the Elasticsearch cluster
+# and have it return a response:
+response = es.indices.create(
+    index=elastic_index,
+    body=es_mapping,
+    ignore=400 # ignore 400 already exists code
+)
+
+if 'acknowledged' in response:
+    if response['acknowledged'] == True:
+        print ("INDEX MAPPING SUCCESS FOR INDEX:", response['index'])
+
+
+# Define Training Set Structure
+tweetKafka = tp.StructType([
+    tp.StructField(name= 'id_str', dataType= tp.StringType(),  nullable= True),
+    tp.StructField(name= 'created_at', dataType= tp.StringType(),  nullable= True),
+    tp.StructField(name= 'text',       dataType= tp.StringType(),  nullable= True)
+])
+
+# Training Set Schema
+schema = tp.StructType([
+    tp.StructField(name= 'id', dataType= tp.StringType(),  nullable= True),
+    tp.StructField(name= 'subjective',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'positive',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'negative',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'ironic',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'lpositive',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'lnegative',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'top',       dataType= tp.IntegerType(),  nullable= True),
+    tp.StructField(name= 'text',       dataType= tp.StringType(),   nullable= True)
+])
+
+sparkConf = SparkConf().set("es.nodes", "elasticsearch") \
+                        .set("es.port", "9200")
+
+sc = SparkContext(appName="TapSentiment", conf=sparkConf)
+spark = SparkSession(sc)
+sc.setLogLevel("WARN")
+
+# read the dataset  
+training_set = spark.read.csv('../tap/spark/dataset/training_set_sentipolc16.csv',
+                         schema=schema,
+                         header=True,
+                         sep=',')
+
+# define stage 1: tokenize the tweet text    
+stage_1 = RegexTokenizer(inputCol= 'text' , outputCol= 'tokens', pattern= '\\W')
+# define stage 2: remove the stop words
+stage_2 = StopWordsRemover(inputCol= 'tokens', outputCol= 'filtered_words')
+# define stage 3: create a word vector of the size 100
+stage_3 = Word2Vec(inputCol= 'filtered_words', outputCol= 'vector', vectorSize= 100)
+# define stage 4: Logistic Regression Model
+model = LogisticRegression(featuresCol= 'vector', labelCol= 'positive')
+# setup the pipeline
+pipeline = Pipeline(stages= [stage_1, stage_2, stage_3, model])
+
+# fit the pipeline model with the training data
+pipelineFit = pipeline.fit(training_set)
+
+modelSummary=pipelineFit.stages[-1].summary
+modelSummary.accuracy
+
+# Streaming Query
+
+# Read the stream from kafka
+df = spark \
+    .readStream \
+    .format("kafka") \
+    .option("kafka.bootstrap.servers", kafkaServer) \
+    .option("subscribe", topic) \
+    .load()
+
+# Cast the message received from kafka with the provided schema
+df = df.selectExpr("CAST(value AS STRING)") \
+    .select(from_json("value", tweetKafka).alias("data")) \
+    .select("data.*")
+
+# Apply the machine learning model and select only the interesting columns
+df = pipelineFit.transform(df) \
+    .select("id_str", "created_at", "text", "prediction")
+
+# Write the stream to elasticsearch
+df.writeStream \
+    .option("checkpointLocation", "/save/location") \
+    .format("es") \
+    .start(elastic_index) \
+    .awaitTermination()
+ 

--- a/twitter_logstash-kafka-spark-elastic/docker-compose.yaml
+++ b/twitter_logstash-kafka-spark-elastic/docker-compose.yaml
@@ -1,0 +1,101 @@
+version: '3.8'
+
+services: 
+    zookeeper:
+        image: confluentinc/cp-zookeeper:6.1.1
+        container_name: zookeeper
+        ports:
+            - "2181:2181"
+        environment:
+            ZOOKEEPER_CLIENT_PORT: 2181
+            ZOOKEEPER_SERVER_ID: "1"
+        networks: 
+                - tap
+
+    kafkaserver:
+        image: confluentinc/cp-kafka:6.1.1
+        container_name: kafkaserver
+        hostname: kafkaServer
+        depends_on:
+          - zookeeper
+        ports:
+          - "9092:9092"
+        environment:
+          KAFKA_BROKER_ID: 0
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafkaserver:9092
+          KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+        networks: 
+            - tap
+
+    webui:
+        image: provectuslabs/kafka-ui:latest
+        container_name: kafkaWebUI
+        environment:
+            KAFKA_CLUSTERS_0_NAME: my_cluster
+            KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafkaServer:9092
+        ports: 
+            - 8080:8080
+        depends_on: 
+            - kafkaserver
+        networks: 
+            - tap
+
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
+        container_name: elasticsearch
+        ports:
+            - "9200:9200"
+        environment:
+            - node.name=elasticsearch
+            - cluster.name=elasticsearch-docker-cluster
+            - discovery.seed_hosts=elasticsearch
+            - cluster.initial_master_nodes=elasticsearch
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        networks: 
+            - tap
+
+    kibana:
+        image: docker.elastic.co/kibana/kibana:7.12.1
+        container_name: kibana
+        ports:
+            - "5601:5601"
+        depends_on: 
+            - elasticsearch
+        networks: 
+            - tap
+    
+    spark:
+        build: 
+            context: ../spark
+            dockerfile: ./Dockerfile
+        image: tap:spark
+        container_name: spark
+        command: ["twitter_stream_elastic.py", "org.apache.spark:spark-sql-kafka-0-10_2.12:3.1.1,org.elasticsearch:elasticsearch-spark-30_2.12:7.12.1"]
+        environment: 
+            SPARK_ACTION: "spark-submit-python"
+        ports: 
+            - "4040:4040"
+        depends_on: 
+            - kafkaserver
+            - elasticsearch
+        networks: 
+            - tap
+    
+    logstash:
+        build: 
+            context: ../logstash_to_kafka
+            dockerfile: ./Dockerfile
+        image: tap:logstash_to_kafka
+        container_name: logstash_to_kafka
+        depends_on: 
+            - kafkaserver
+        networks: 
+            - tap
+networks:
+    tap:
+        name: tap
+        driver: bridge


### PR DESCRIPTION
Sono state introdotte le seguenti modifiche:
- *_kibana/docker-compose-tend.yaml_: *semplice dockerfile di comodità per lanciare contemporaneamente kibana ed elasticsearch
- *cartella logstash_to_kafka:* cartella ~dalla dubbia utilità~ che presenta un immagine di logstash pronta ad usare kafka come sink
- *aggiunto spark/code/twitter_stream_elastic.py:* versione leggermente modificata di _spark/code/wip.py_ che evita il _foreach_ preferendo il _writeStream.format()_
- *_twitter_logstash-kafka-spark-elastic/docker-compose.yaml_:* docker compose file che contiene l'intera pipeline