### PR TITLE
Aggiunto il doppio stream (forse)

### DIFF
--- a/logstash_to_kafka/pipeline/logstash.conf
+++ b/logstash_to_kafka/pipeline/logstash.conf
@@ -18,4 +18,10 @@ output {
     topic_id => "tweet"
     bootstrap_servers => "kafkaserver:9092"
   }
+  elasticsearch {
+        hosts => ["elasticsearch:9200"]
+        index => "taptweet"
+        document_id => "id_str"
+        doc_as_upsert => true
+  }
 }

--- a/spark/code/twitter_stream_elastic.py
+++ b/spark/code/twitter_stream_elastic.py
@@ -68,7 +68,9 @@ schema = tp.StructType([
 ])
 
 sparkConf = SparkConf().set("es.nodes", "elasticsearch") \
-                        .set("es.port", "9200")
+                        .set("es.port", "9200") \
+                        .set("es.mapping.id", "id_str") \
+                        .set("es.write.operation", "upsert")
 
 sc = SparkContext(appName="TapSentiment", conf=sparkConf)
 spark = SparkSession(sc)


### PR DESCRIPTION
Era questo il doppio stream che intendeva?
In questa maniera il tweet viene inviato da logstash direttamente su elasticsearch (con tutti i campi contenuti in tweet) e poi spark aggiunge il campo prediction